### PR TITLE
gh-48: Feat: 홈 이벤트, 포토부스 목록 조회 API 및 관련 테스트 코드 작성 

### DIFF
--- a/dump_in/events/selectors/events.py
+++ b/dump_in/events/selectors/events.py
@@ -14,6 +14,9 @@ class EventSelector:
         except Event.DoesNotExist:
             return None
 
+    def get_event_queryset_order_by_created_at_desc(self) -> QuerySet[Event]:
+        return Event.objects.filter(is_public=True, photo_booth_brand__is_event=True).order_by("-created_at")
+
     def get_event_with_user_info_by_id(self, event_id: int, user_id) -> Optional[Event]:
         try:
             qs = Event.objects.filter(id=event_id, is_public=True, photo_booth_brand__is_event=True)

--- a/dump_in/events/urls.py
+++ b/dump_in/events/urls.py
@@ -1,9 +1,10 @@
 from django.urls import path
 
-from dump_in.events.apis import EventDetailAPI, EventLikeAPI, EventListAPI
+from dump_in.events.apis import EventDetailAPI, EventHomeAPI, EventLikeAPI, EventListAPI
 
 urlpatterns = [
     path("", EventListAPI.as_view(), name="event-list"),
+    path("/home", EventHomeAPI.as_view(), name="event-home"),
     path("/<int:event_id>", EventDetailAPI.as_view(), name="event-detail"),
     path("/<int:event_id>/likes", EventLikeAPI.as_view(), name="event-like"),
 ]

--- a/dump_in/photo_booths/selectors/photo_booth_brands.py
+++ b/dump_in/photo_booths/selectors/photo_booth_brands.py
@@ -15,3 +15,6 @@ class PhotoBoothBrandSelector:
 
         except PhotoBoothBrand.DoesNotExist:
             return None
+
+    def get_photo_booth_brand_queryset_order_by_name_asc(self) -> QuerySet[PhotoBoothBrand]:
+        return PhotoBoothBrand.objects.all().order_by("name")

--- a/dump_in/photo_booths/urls.py
+++ b/dump_in/photo_booths/urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 from dump_in.photo_booths.apis import (
     PhotoBoothBrandDetailAPI,
     PhotoBoothBrandEventListAPI,
+    PhotoBoothBrandHomeAPI,
     PhotoBoothBrandListAPI,
     PhotoBoothBrandReviewListAPI,
     PhotoBoothDetailAPI,
@@ -14,6 +15,7 @@ from dump_in.photo_booths.apis import (
 
 urlpatterns = [
     path("/brands", PhotoBoothBrandListAPI.as_view(), name="photo-booth-brand-list"),
+    path("/brands/home", PhotoBoothBrandHomeAPI.as_view(), name="photo-booth-brand-home"),
     path("/brands/<int:photo_booth_brand_id>", PhotoBoothBrandDetailAPI.as_view(), name="photo-booth-brand-detail"),
     path("/brands/<int:photo_booth_brand_id>/events", PhotoBoothBrandEventListAPI.as_view(), name="photo-booth-brand-event-list"),
     path("/brands/<int:photo_booth_brand_id>/reviews", PhotoBoothBrandReviewListAPI.as_view(), name="photo-booth-brand-review-list"),

--- a/dump_in/reviews/apis.py
+++ b/dump_in/reviews/apis.py
@@ -59,7 +59,7 @@ class ReviewListAPI(APIView):
     def get(self, request: Request) -> Response:
         """
         포토부스에 대한 리뷰 목록을 조회합니다.
-        url: /app/api/reviews/
+        url: /app/api/reviews
         """
         filter_serializer = self.FilterSerializer(data=request.query_params)
         filter_serializer.is_valid(raise_exception=True)
@@ -99,7 +99,7 @@ class ReviewListAPI(APIView):
     def post(self, request: Request) -> Response:
         """
         인증된 사용자가 포토부스에 대한 리뷰를 생성합니다.
-        url: /app/api/reviews/
+        url: /app/api/reviews
         """
         input_serializer = self.InputSerializer(data=request.data)
         input_serializer.is_valid(raise_exception=True)

--- a/tests/events/apis/test_event_home.py
+++ b/tests/events/apis/test_event_home.py
@@ -7,7 +7,7 @@ pytestmark = pytest.mark.django_db
 
 
 class TestEventList(IsAuthenticateTestCase):
-    url = reverse("api-events:event-list")
+    url = reverse("api-events:event-home")
 
     def test_event_list_get_success_single_event(self, valid_user, valid_event):
         access_token = self.obtain_token(valid_user)
@@ -24,8 +24,6 @@ class TestEventList(IsAuthenticateTestCase):
         assert response.data["data"]["results"][0]["id"] == valid_event.id
         assert response.data["data"]["results"][0]["title"] == valid_event.title
         assert response.data["data"]["results"][0]["main_thumbnail_image_url"] == valid_event.main_thumbnail_image_url
-        assert not response.data["data"]["results"][0]["is_liked"]
-        assert response.data["data"]["results"][0]["photo_booth_brand_name"] == valid_event.photo_booth_brand.name
 
     def test_event_list_get_success_pagination(self, valid_user, valid_event_list):
         access_token = self.obtain_token(valid_user)
@@ -41,37 +39,6 @@ class TestEventList(IsAuthenticateTestCase):
         assert response.status_code == 200
         assert response.data["data"]["count"] == len(valid_event_list)
         assert len(response.data["data"]["results"]) == 10
-
-    def test_event_list_get_success_with_filter(self, valid_event, valid_user):
-        access_token = self.obtain_token(valid_user)
-        self.authenticate_with_token(access_token)
-        response = self.client.get(
-            path=self.url,
-            data={"hashtag": valid_event.hashtag.first().name},
-        )
-
-        assert response.status_code == 200
-        assert response.data["data"]["results"][0]["id"] == valid_event.id
-        assert response.data["data"]["results"][0]["title"] == valid_event.title
-        assert response.data["data"]["results"][0]["main_thumbnail_image_url"] == valid_event.main_thumbnail_image_url
-        assert not response.data["data"]["results"][0]["is_liked"]
-        assert response.data["data"]["results"][0]["photo_booth_brand_name"] == valid_event.photo_booth_brand.name
-
-    def test_event_list_get_success_anonymous_user(self, valid_event):
-        response = self.client.get(
-            path=self.url,
-            data={
-                "limit": 1,
-                "offset": 0,
-            },
-        )
-
-        assert response.status_code == 200
-        assert response.data["data"]["results"][0]["id"] == valid_event.id
-        assert response.data["data"]["results"][0]["title"] == valid_event.title
-        assert response.data["data"]["results"][0]["main_thumbnail_image_url"] == valid_event.main_thumbnail_image_url
-        assert response.data["data"]["results"][0]["is_liked"] is None
-        assert response.data["data"]["results"][0]["photo_booth_brand_name"] == valid_event.photo_booth_brand.name
 
     def test_event_list_get_fail_limit_min_value(self, valid_user):
         access_token = self.obtain_token(valid_user)
@@ -117,20 +84,6 @@ class TestEventList(IsAuthenticateTestCase):
         assert response.status_code == 400
         assert response.data["code"] == "invalid_parameter_format"
         assert response.data["message"] == {"offset": ["Ensure this value is greater than or equal to 0."]}
-
-    def test_event_list_get_fail_hashtag_choices(self, valid_user):
-        access_token = self.obtain_token(valid_user)
-        self.authenticate_with_token(access_token)
-        response = self.client.get(
-            path=self.url,
-            data={
-                "hashtag": "invalid",
-            },
-        )
-
-        assert response.status_code == 400
-        assert response.data["code"] == "invalid_parameter_format"
-        assert response.data["message"] == {"hashtag": ['"invalid" is not a valid choice.']}
 
     def test_event_list_get_fail_limit_invalid_format(self, valid_user):
         access_token = self.obtain_token(valid_user)

--- a/tests/events/selectors/test_get_event_queryset_order_by_created_at_desc.py
+++ b/tests/events/selectors/test_get_event_queryset_order_by_created_at_desc.py
@@ -1,0 +1,25 @@
+import pytest
+
+from dump_in.events.selectors.events import EventSelector
+
+pytestmark = pytest.mark.django_db
+
+
+class TestGetEventQuerysetOrderByCreatedAtDesc:
+    def setup_method(self):
+        self.event_selector = EventSelector()
+
+    def test_get_event_queryset_order_by_created_at_desc_success(self, valid_event_list):
+        event_queryset = self.event_selector.get_event_queryset_order_by_created_at_desc()
+
+        sorted_event_list = sorted(valid_event_list, key=lambda x: x.created_at, reverse=True)
+
+        assert event_queryset.count() == len(sorted_event_list)
+        assert event_queryset[0].created_at == sorted_event_list[0].created_at
+        assert event_queryset[1].created_at == sorted_event_list[1].created_at
+        assert event_queryset[2].created_at == sorted_event_list[2].created_at
+
+    def test_get_event_queryset_order_by_created_at_desc_fail_does_not_exist(self):
+        event_queryset = self.event_selector.get_event_queryset_order_by_created_at_desc()
+
+        assert event_queryset.count() == 0

--- a/tests/photo_booths/selectors/photo_booth_brands/test_get_photo_booth_brand_queryset_order_by_name_asc.py
+++ b/tests/photo_booths/selectors/photo_booth_brands/test_get_photo_booth_brand_queryset_order_by_name_asc.py
@@ -1,0 +1,25 @@
+import pytest
+
+from dump_in.photo_booths.selectors.photo_booth_brands import PhotoBoothBrandSelector
+
+pytestmark = pytest.mark.django_db
+
+
+class TestGetPhotoBoothBrandQuerysetOrderByNameAsc:
+    def setup_method(self):
+        self.photo_booth_brand_selector = PhotoBoothBrandSelector()
+
+    def test_get_photo_booth_brand_queryset_order_by_name_asc_success(self, photo_booth_brand_list):
+        photo_booth_brand_queryset = self.photo_booth_brand_selector.get_photo_booth_brand_queryset_order_by_name_asc()
+
+        sorted_photo_booth_brand_list = sorted(photo_booth_brand_list, key=lambda x: x.name)
+
+        assert photo_booth_brand_queryset.count() == len(sorted_photo_booth_brand_list)
+        assert photo_booth_brand_queryset[0].name == sorted_photo_booth_brand_list[0].name
+        assert photo_booth_brand_queryset[1].name == sorted_photo_booth_brand_list[1].name
+        assert photo_booth_brand_queryset[2].name == sorted_photo_booth_brand_list[2].name
+
+    def test_get_photo_booth_brand_queryset_order_by_name_asc_fail_does_not_exist(self):
+        photo_booth_brand_queryset = self.photo_booth_brand_selector.get_photo_booth_brand_queryset_order_by_name_asc()
+
+        assert photo_booth_brand_queryset.count() == 0


### PR DESCRIPTION
## PR 체크리스트
아래 항목을 확인해 주세요:

- [x] 커밋 메시지가 우리의 가이드라인을 따르고 있는지 확인하세요
- [x] 변경 사항에 대한 테스트가 추가되었는지 확인하세요 (버그 수정 / 기능 추가)
- [x] 문서가 추가되거나 업데이트되었는지 확인하세요 (버그 수정 / 기능 추가)

## PR 유형
이 PR은 어떤 종류의 변경을 가져오나요?

<!-- 이 PR에 해당하는 것을 "x"로 표시하세요. -->

- [ ] 버그 수정
- [x] 새로운 기능 추가
- [ ] 코드 스타일 업데이트 (서식, 로컬 변수)
- [x] 리팩터링 (기능 변경 없음, API 변경 없음)
- [ ] 빌드 관련 변경
- [ ] CI 관련 변경
- [ ] 문서 내용 변경
- [ ] 애플리케이션 / 인프라 변경
- [ ] 기타... 설명:

## 관련 이슈
이슈 번호: #48 

## 어떤 동작은 무엇인가요?
 - 홈 이벤트 목록 조회 API 작성
 - 위에 관련된 것 테스트 코드 작성
 - 홈 포토부스 목록 조회 API 작성
 - 위에 관련된 것 테스트 코드 작성
 - API 문서 작성

기존에 홈 화면에서 리뷰 리스트에 포토부스, 이벤트를 함께 담아 보내려고 했지만 프론트 개발자분들과 상의 후 하나의 API에 여러 동작을 수행하는 것 같아 나눌 필요성이 있어서 나눔, 또는 성능면에서 포토부스, 이벤트 데이터 양도 많지 않고 페이지네이션 1개만 요청하기에 무리 없다고 판단함

## 이 PR은 호환성 변경을 도입하나요?

- [ ] 예
- [x] 아니요

<!-- 이 PR에 호환성 변경이 포함되어 있다면, 기존 응용 프로그램에 대한 영향과 마이그레이션 경로를 아래에 설명해 주세요. -->

## 기타 정보
![image](https://github.com/develop-pix/dump-in-app-BE/assets/104830931/daaa4de2-7f59-410e-ae26-7212295a8f3f)
<img width="1405" alt="image" src="https://github.com/develop-pix/dump-in-app-BE/assets/104830931/c19fd233-c2d4-4b9d-bdcc-5d1507cde60c">